### PR TITLE
Remove requirement of using node version 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,5 @@
     "taskcluster-client": "^2.1.0",
     "uuid": "^2.0.2"
   },
-  "main": "./lib/datacontainer",
-  "engines": {
-    "node": "4.x"
-  }
+  "main": "./lib/datacontainer"
 }


### PR DESCRIPTION
This is blocking us from using a newer version of node in production of the provisioner.