### PR TITLE
Version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The constructor of the DataContainer takes the following options:
   accessLevel:       'read-write',           // The access level of the container: read-only/read-write (optional)
   authBaseUrl:       '...',                  // baseUrl for auth (optional)
   schema:            '...',                  // JSON schema object
+  schemaVersion:     1,                      // JSON schema version. (optional)
+                                             // The default value is 1.
 
   // Max number of update blob request retries
   updateRetries:              10,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,4 @@
 module.exports = {
   /* Timeout for azure blob requests */
   AZURE_BLOB_TIMEOUT: 7 * 1000,
-
-  /* The name of the json schema*/
-  JSON_SCHEMA_NAME:   '.schema.json',
 };

--- a/src/customerrors.js
+++ b/src/customerrors.js
@@ -25,8 +25,15 @@ class BlobSerializationError extends ExtendableError {
   }
 }
 
+class SchemaIntegrityCheckError extends ExtendableError {
+  constructor(message) {
+    super(message, 'SchemaIntegrityCheckError', 'SchemaIntegrityCheck');
+  }
+}
+
 module.exports = {
   CongestionError,
   SchemaValidationError,
   BlobSerializationError,
+  SchemaIntegrityCheckError,
 };

--- a/src/datablob.js
+++ b/src/datablob.js
@@ -44,8 +44,8 @@ class DataBlob {
     this.cacheControl = options.cacheControl;
   }
 
-  _validateJSON(content) {
-    let valid = this.container.validate(content);
+  async _validateJSON(content) {
+    let valid = await this.container.validate(content);
     if (!valid) {
       debug(`Failed to validate the blob content against schema with id: 
           ${this.container.schema.id}, errors: ${this.container.validate.errors}`);
@@ -147,7 +147,7 @@ class DataBlockBlob extends DataBlob {
 
       let content = JSON.parse(blob.content).content;
       // Validate the JSON against the schema
-      this._validateJSON(content);
+      await this._validateJSON(content);
       this._cache(content);
       return content;
     } catch (error) {
@@ -168,7 +168,7 @@ class DataBlockBlob extends DataBlob {
     assert(content, 'content must be specified');
 
     // 1. Validate the content against the schema
-    this._validateJSON(content);
+    await this._validateJSON(content);
 
     // 2. store the blob
     await super._create(this._serialize(content));
@@ -217,7 +217,7 @@ class DataBlockBlob extends DataBlob {
         modifiedContent = clonedContent;
 
         // 3. validate against the schema
-        this._validateJSON(clonedContent);
+        await this._validateJSON(clonedContent);
 
         // 4. update the resource
         options.ifMatch = this.eTag;
@@ -282,7 +282,7 @@ class AppendDataBlob extends DataBlob {
    */
   async append(content) {
     // 1. validate the content against the schema
-    this._validateJSON(content);
+    await this._validateJSON(content);
 
     // 2. append the new content
     try {

--- a/src/datablob.js
+++ b/src/datablob.js
@@ -52,7 +52,7 @@ class DataBlob {
       let error = new SchemaValidationError(`Failed to validate the blob content against schema with id: 
                                             ${this.container.schema.id}`);
       error.content = content;
-      error.validationErrors = this.container.validate.errors;
+      error.validationErrors = this.container.validate.errors; //TODO nu mai am access la error
       throw error;
     }
   }

--- a/src/datacontainer.js
+++ b/src/datacontainer.js
@@ -115,6 +115,8 @@ class DataContainer {
 
     this.blobService = blobService;
     this.name        = options.container;
+    // _validateFunctionMap is a mapping from schema version to validation function generated
+    // after the ajv schema compile
     this._validateFunctionMap = {};
 
     this.schema      = options.schema;
@@ -187,6 +189,7 @@ class DataContainer {
     } catch (error) {
       if (error.code === 'BlobNotFound') {
         this._saveSchema();
+
         this._validateFunctionMap[this.schemaVersion] = this.validator.compile(this.schema);
         return;
       }

--- a/test-src/appendblob_test.js
+++ b/test-src/appendblob_test.js
@@ -3,7 +3,7 @@ import DataContainer from '../lib/datacontainer';
 import {AppendDataBlob}    from '../lib/datablob';
 import uuid          from 'uuid';
 import _debug        from 'debug';
-const debug = _debug('azure-blob-storage-test:appenddatablob');
+const debug = _debug('azure-blob-storage-test:append-data-blob');
 import {logSchema, credentials}      from './helpers';
 
 describe('Azure Blob Storage - Append Data Blob Tests', () => {

--- a/test-src/appendblob_test.js
+++ b/test-src/appendblob_test.js
@@ -3,9 +3,8 @@ import DataContainer from '../lib/datacontainer';
 import {AppendDataBlob}    from '../lib/datablob';
 import uuid          from 'uuid';
 import _debug        from 'debug';
-const debug = _debug('azure-blob-storage-test:data-container');
+const debug = _debug('azure-blob-storage-test:appenddatablob');
 import {logSchema, credentials}      from './helpers';
-import {sleep}       from '../lib/utils';
 
 describe('Azure Blob Storage - Append Data Blob Tests', () => {
   let dataContainer;
@@ -83,6 +82,6 @@ describe('Azure Blob Storage - Append Data Blob Tests', () => {
         'A SchemaValidationError should have been thrown for invalid data');
       return;
     }
-    assume(false).is.true('Expected an error when trying to modify a deleted blob.');
+    assume(false).is.true('Expected an error when trying to append invalid content.');
   });
 });

--- a/test-src/helpers.js
+++ b/test-src/helpers.js
@@ -7,6 +7,15 @@ let schemaObj = JSON.parse(schema);
 let logSchema = fs.readFileSync(`${__dirname}/schemas/log_schema.json`, 'utf8');
 let logSchemObj = JSON.parse(logSchema);
 
+let logSchemaV2 = fs.readFileSync(`${__dirname}/schemas/log_schemaV2.json`, 'utf8');
+let logSchemV2Obj = JSON.parse(logSchemaV2);
+
+let schemaV1 = fs.readFileSync(`${__dirname}/schemas/schema_v1.json`, 'utf8');
+let schemaV1Obj = JSON.parse(schemaV1);
+
+let schemaV2 = fs.readFileSync(`${__dirname}/schemas/schema_v2.json`, 'utf8');
+let schemaV2Obj = JSON.parse(schemaV2);
+
 let cfg = config({});
 let credentials = {
   accountName: cfg.azureBlob.accountName,
@@ -16,5 +25,8 @@ let credentials = {
 module.exports = {
   schema: schemaObj,
   logSchema: logSchemObj,
+  logSchemaV2: logSchemV2Obj,
+  schemaV1: schemaV1Obj,
+  schemaV2: schemaV2Obj,
   credentials: credentials,
 };

--- a/test-src/schemas/log_schemaV2.json
+++ b/test-src/schemas/log_schemaV2.json
@@ -1,0 +1,21 @@
+{
+  "$schema":      "http://json-schema.org/draft-04/schema#",
+  "title":        "test json schema",
+  "type":         "object",
+  "properties": {
+    "event": {
+      "type":           "string"
+    },
+    "code": {
+      "type":           "integer"
+    },
+    "reason": {
+      "type":           "string"
+    },
+    "location": {
+      "type":           "string"
+    }
+  },
+  "additionalProperties":   false,
+  "required": ["event", "code", "reason", "location"]
+}

--- a/test-src/schemas/schema_v1.json
+++ b/test-src/schemas/schema_v1.json
@@ -1,0 +1,12 @@
+{
+  "$schema":      "http://json-schema.org/draft-04/schema#",
+  "title":        "schema version 1",
+  "type":         "object",
+  "properties": {
+    "value": {
+      "type":           "integer"
+    }
+  },
+  "additionalProperties":   false,
+  "required": ["value"]
+}

--- a/test-src/schemas/schema_v2.json
+++ b/test-src/schemas/schema_v2.json
@@ -1,0 +1,12 @@
+{
+  "$schema":      "http://json-schema.org/draft-04/schema#",
+  "title":        "schema version 2",
+  "type":         "object",
+  "properties": {
+    "name": {
+      "type":           "string"
+    }
+  },
+  "additionalProperties":   false,
+  "required": ["name"]
+}

--- a/test-src/taskcluster_auth_test.js
+++ b/test-src/taskcluster_auth_test.js
@@ -8,7 +8,7 @@ import assume         from 'assume';
 import path           from 'path';
 import {schema, credentials}       from './helpers';
 
-describe('Data Container - Tests for authentication with SAS from auth.taskcluster.net', () => {
+describe.only('Data Container - Tests for authentication with SAS from auth.taskcluster.net', () => {
   var callCount = 0;
   var returnExpiredSAS = false;
   // Create test api
@@ -162,6 +162,7 @@ describe('Data Container - Tests for authentication with SAS from auth.taskclust
 
   it('should create a data block blob', async () => {
     callCount = 0;
+    console.dir(dataContainer);
     await dataContainer.createDataBlockBlob({
       name: 'blobTest',
     }, {

--- a/test-src/taskcluster_auth_test.js
+++ b/test-src/taskcluster_auth_test.js
@@ -119,6 +119,7 @@ describe('Data Container - Tests for authentication with SAS from auth.taskclust
   after(async () => {
     await server.terminate();
     testing.fakeauth.stop();
+    // delete the container created
   });
 
   it('should create an instance of data container', async () => {
@@ -168,7 +169,7 @@ describe('Data Container - Tests for authentication with SAS from auth.taskclust
       value: 50,
     });
 
-    // nu se mai face call la auth pentru s-a facut deja atunci cand s-a cache-uit schema
+    // the auth won't be called because it was already called in order to cache the schema
     assume(callCount).equals(0);
   });
 
@@ -192,44 +193,12 @@ describe('Data Container - Tests for authentication with SAS from auth.taskclust
         value: 50,
       });
 
-      assume(callCount).equals(2, 'azureBlobSAS should have been called once.');
+      assume(callCount).equals(2, 'azureBlobSAS should have been called twice.');
 
       await testing.sleep(200);
       let content = await blob.load();
 
-      assume(callCount).equals(3, 'azureBlobSAS should have been called twice.');
-    } catch (error) {
-      assume(false).is.true('Expected no error.');
-    }
-  });
-
-  it('create two data block blobs in parallel, only gets SAS once', async () => {
-    try {
-      dataContainer = await DataContainer({
-        account: credentials.accountName,
-        container: containerName,
-        credentials: {
-          clientId: 'authed-client',
-          accessToken: 'test-token',
-        },
-        authBaseUrl: 'http://localhost:1208',
-        schema: schema,
-      });
-      callCount = 0;
-      await Promise.all([
-        dataContainer.createDataBlockBlob({
-          name: 'blobTest2',
-        }, {
-          value: 50,
-        }),
-        dataContainer.createDataBlockBlob({
-          name: 'blobTest3',
-        }, {
-          value: 50,
-        }),
-      ]);
-
-      assume(callCount).equals(1);
+      assume(callCount).equals(3, 'azureBlobSAS should have been called three times.');
     } catch (error) {
       assume(false).is.true('Expected no error.');
     }

--- a/test-src/version_test.js
+++ b/test-src/version_test.js
@@ -1,0 +1,162 @@
+import _debug             from 'debug';
+const debug = _debug('azure-blob-storage-test:version');
+import {schemaV1, schemaV2, logSchema, logSchemaV2, credentials}      from './helpers';
+import uuid               from 'uuid';
+import DataContainer      from '../lib/datacontainer';
+import assume             from 'assume';
+import {DataBlockBlob}    from '../lib/datablob';
+
+describe('Azure Blob Storage - Data Container Version Support', () => {
+
+  let containerName = `${uuid.v4()}`;
+  let logContainerName = `${uuid.v4()}`;
+  let blobV1Name = 'blobV1';
+  let blobV2Name = 'blobV2';
+  let appendBlobName = 'appendBlob';
+  let dataContainerV1;
+  let dataContainerV2;
+  let logContainerV1;
+  let logContainerV2;
+
+  before(async () =>{
+    assume(credentials.accountName).is.ok();
+    assume(credentials.accountKey).is.ok();
+
+    dataContainerV1 = await DataContainer({
+      credentials: credentials,
+      schema: schemaV1,
+      schemaVersion: 1,
+      container: containerName,
+    });
+
+    dataContainerV2 = await DataContainer({
+      credentials: credentials,
+      schema: schemaV2,
+      schemaVersion: 2,
+      container: containerName,
+    });
+
+    logContainerV1 = await DataContainer({
+      credentials: credentials,
+      schema: logSchema,
+      schemaVersion: 1,
+      container: logContainerName,
+    });
+
+    logContainerV2 = await DataContainer({
+      credentials: credentials,
+      schema: logSchemaV2,
+      schemaVersion: 2,
+      container: logContainerName,
+    });
+  });
+
+  after(async () => {
+    if (dataContainerV1) {
+      await dataContainerV1.removeContainer();
+    }
+    if (dataContainerV2) {
+      await dataContainerV2.removeContainer();
+    }
+
+    if (logContainerV1) {
+      await logContainerV1.removeContainer();
+    }
+    if (logContainerV2) {
+      await logContainerV2.removeContainer();
+    }
+  });
+
+  it('should create a dataBlockBlob in a container with version 1 of schema', async () => {
+    let blobName = `${blobV1Name}`;
+    debug(`create a dataBlockBlob with name: ${blobName}`);
+    let blob = await dataContainerV1.createDataBlockBlob({
+      name: blobName,
+    }, {
+      value: 40,
+    });
+
+    debug('check if the data block blob was created');
+    let list = await dataContainerV1.listBlobs({
+      prefix: blobName,
+    });
+    assume(list).exists();
+    let blobs = list.blobs;
+    assume(blobs).is.array();
+    assume(blobs.length).equals(1);
+    assume(blobs[0] instanceof DataBlockBlob).is.ok();
+
+    debug('check the content of the data block blob created.');
+    let data = await blob.load();
+    assume(data.value).equals(40);
+  });
+
+  it('should create a dataBlockBlob in a data container with version 2 of json schema', async () => {
+    let blobName = `${blobV2Name}`;
+    debug(`create a dataBlockBlob with name: ${blobName}`);
+    let blob = await dataContainerV2.createDataBlockBlob({
+      name: blobName,
+    }, {
+      name: 'blobV2',
+    });
+
+    debug('check if the data block blob was created');
+    let list = await dataContainerV2.listBlobs({
+      prefix: blobName,
+    });
+    assume(list).exists();
+    let blobs = list.blobs;
+    assume(blobs).is.array();
+    assume(blobs.length).equals(1);
+    assume(blobs[0] instanceof DataBlockBlob).is.ok();
+
+    debug('check the content of the data block blob created.');
+    let data = await blob.load();
+    assume(data.name).equals('blobV2');
+  });
+
+  it('should load a dataBlockBlob with v1 from a data container with v2', async () => {
+    debug('load the blob created with v1 of the schema');
+    let blobV1 = await dataContainerV2.load(blobV1Name, true);
+
+    debug(`update the content of the blob: ${blobV1Name}`);
+    let modifier = (data) => {
+      data.value = 100;
+    };
+    await blobV1.modify(modifier);
+
+    debug('test the content updated');
+    let content = await blobV1.load();
+    assume(content.value).equals(100);
+  });
+
+  it('should create an append data blob with version 1 of schema, update the content with v2', async () => {
+    debug(`create an append data blob with name ${appendBlobName}`);
+    let appendBlob = await logContainerV1.createAppendDataBlob({name: appendBlobName});
+
+    debug('append data with v1');
+    let logV1 = {
+      event: 'serverfault',
+      code: 5234,
+      reason: 'Disk full',
+    };
+    await appendBlob.append(logV1);
+
+    let content = await appendBlob.load();
+    assume(content).equals(JSON.stringify(logV1));
+
+    appendBlob = await logContainerV2.load(appendBlobName);
+
+    debug('append data with v2');
+    let logV2 = {
+      event: 'networkfault',
+      code: 5236,
+      reason: 'Connetion error',
+      location: 'US',
+    };
+    await appendBlob.append(logV2);
+
+    content = await appendBlob.load();
+    assume(content).equals(JSON.stringify(logV1)+JSON.stringify(logV2));
+  });
+});


### PR DESCRIPTION
Version support
- the JSON schema will be stored in a block blob. The name of the blob will contain the information about the version of the schema.
	blobName: .schema.v1.json
			  .schema.v2.json
- the constructor of the data container has been modified in order to receive the schema version along with schema object;
- the newly blobs will be validated against the schema defined at construct time of the data container;
- the schema version information that is used to validate the content of a blob, is saved with the content of the blob.
	{
		content: '...',	// the stringify json
		version: 1        // schema version
	}
- if you try to modify an existing blob:
1. the schema version is read from the blob 
2. the content will be validated against the schema with that version. 
 
- a data container can have multiple version of schema: the schemas will be loaded and cached on demand (only when you try to modify a blob that has been created with an older version of schema)
- for append blobs: the newly appended json objects will follow the schema defined at construct time of the data container.